### PR TITLE
Keep line feeds when wrapping text

### DIFF
--- a/src/main/kotlin/Text.kt
+++ b/src/main/kotlin/Text.kt
@@ -19,6 +19,7 @@
 package com.xenomachina.text
 
 const val NBSP_CODEPOINT = 0xa0
+const val LINE_FEED_CODEPOINT = 0x0a
 
 /**
  * Produces a [Sequence] of the Unicode code points in the given [String].

--- a/src/test/kotlin/TextTermTest.kt
+++ b/src/test/kotlin/TextTermTest.kt
@@ -99,6 +99,54 @@ class String_WrapTextTest : FunSpec() {
             "你好 is 'hi' in Chinese".wrapText(10) shouldBe
             "你好 is\n'hi' in\nChinese"
         }
+
+        test("single new-line character is treated as space") {
+            "1...\n2...".wrapText(10) shouldBe
+            "1... 2..."
+        }
+
+        test("multiple new-line characters are treated as markdown paragraphs") {
+            "1...\n\n2...".wrapText(10) shouldBe
+            "1...\n\n2..."
+        }
+
+        test("non-successive new-line characters are treated as markdown paragraphs") {
+            "1...\n   \n 2...".wrapText(10) shouldBe
+            "1...\n\n2..."
+        }
+
+        test("leading multiple new-line characters are removed") {
+            "\n\n1... 2...".wrapText(10) shouldBe
+            "1... 2..."
+        }
+
+        test("trailing multiple new-line characters are removed") {
+            "1... 2...\n\n".wrapText(10) shouldBe
+            "1... 2..."
+        }
+
+        test("mix of multiple new-line characters and spaces should be treated as 'markdown paragraphs' (escaped string version)") {
+            "1...\n2...\n\n \n  \n\n    \n Hello world!".wrapText(10) shouldBe
+            "1... 2...\n\nHello\nworld!"
+        }
+
+        test("mix of multiple new-line characters and spaces should be treated as 'markdown paragraphs' (raw string version)") {
+            """
+                1...
+                2...
+
+
+
+                 Hello world!
+                """.trimStart()
+                    .wrapText(10) shouldBe
+            """
+                1... 2...
+
+                Hello
+                world!
+                """.trimIndent()
+        }
     }
 }
 


### PR DESCRIPTION
Hello!

Here is a "fix" of the text wrapping feature that does not reset the `lineWidth` when a `\n` character is found.

I found this using your (really cool) ArgParser documentation helper.
With this help text : `HMAC signature algorithm and base64 encoded secret key.\nAvailable algorithms : [HS256, HS384, HS512]`
I got this kind of result :
```
  --hmac-sign HMAC_ALG SECRET    HMAC signature algorithm and base64 encoded secret key.
                                 Available
                                 algorithms : [HS256, HS384, HS512]
```

But I expected :
```
   --hmac-sign HMAC_ALG SECRET    HMAC signature algorithm and base64 encoded secret key.
                                  Available algorithms : [HS256, HS384, HS512]
```

Thanks a lot for your tools !